### PR TITLE
Fixed now() function setting invalid date

### DIFF
--- a/scripts/components/CalendarCore.js
+++ b/scripts/components/CalendarCore.js
@@ -587,7 +587,7 @@ CalendarCore.prototype.unsubscribe = function(cb) {
  *
  */
 CalendarCore.prototype.now = function() {
-	this.setSelectedDate(new Date());
+	this.setSelectedDate(this._state_month.date);
 };
 
 /**


### PR DESCRIPTION
now() function returns a new object of Date, which sets the date wrongly. It keeps setting the date to August 1, 2018.

In the CalendarCore._state, there is already a sub-object which is fixated to the current date.